### PR TITLE
Build docs with Python 3.12

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,13 +1,12 @@
 version: 2
 
-python:
-  install:
-    - requirements: requirements.txt
-
 build:
   os: "ubuntu-20.04"
   tools:
     python: "3.12"
+  jobs:
+    pre_build:
+      - python -m pip install --exists-action=w --no-cache-dir --use-pep517 -r requirements.txt
 
 sphinx:
   # myst parser emits warnings for links in md files

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ python:
 build:
   os: "ubuntu-20.04"
   tools:
-    python: "3.8"
+    python: "3.12"
 
 sphinx:
   # myst parser emits warnings for links in md files

--- a/docs/dev_docs.rst
+++ b/docs/dev_docs.rst
@@ -1,7 +1,7 @@
 Developer Documentation
 =======================
 
-All components are hosted at Bitbucket. Development follows `CESSDA
+All components are hosted at Github. Development follows `CESSDA
 Technical Guidelines`_.
 
 All commits are tested in CESSDA CI Platform. The platform also

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,15 +57,15 @@ sphinxcontrib-openapi==0.7.0
 # Application sources
 # -------------------
 
-git+https://bitbucket.org/tietoarkisto/kuha_common@master#egg=kuha_common
-git+https://bitbucket.org/tietoarkisto/kuha_document_store@master#egg=kuha_document_store
-git+https://bitbucket.org/tietoarkisto/kuha_oai_pmh_repo_handler@master#egg=kuha_oai_pmh_repo_handler
-git+https://bitbucket.org/tietoarkisto/kuha_client@master#egg=kuha_client
+git+https://gitlab.tuni.fi/fsd/kuha_common@master#egg=kuha_common
+git+https://gitlab.tuni.fi/fsd/kuha_document_store@master#egg=kuha_document_store
+git+https://gitlab.tuni.fi/fsd/kuha_oai_pmh_repo_handler@master#egg=kuha_oai_pmh_repo_handler
+git+https://gitlab.tuni.fi/fsd/kuha_client@master#egg=kuha_client
 
 # Use editable installs since we're using *.md docs from these repos in documentation
 
--e git+https://bitbucket.org/cessda/cessda.cdc.aggregator.shared-library@0.5.0#egg=cdcagg_common
--e git+https://bitbucket.org/cessda/cessda.cdc.aggregator.doc-store@0.3.0#egg=cdcagg_docstore
--e git+https://bitbucket.org/cessda/cessda.cdc.aggregator.oai-pmh-repo-handler@0.4.0#egg=cdcagg_oai
--e git+https://bitbucket.org/cessda/cessda.cdc.aggregator.client@0.5.0#egg=cdcagg_client
+-e git+https://github.com/cessda/cessda.cdc.aggregator.shared-library@0.7.0#egg=cdcagg_common
+-e git+https://github.com/cessda/cessda.cdc.aggregator.doc-store@0.5.0#egg=cdcagg_docstore
+-e git+https://github.com/cessda/cessda.cdc.aggregator.oai-pmh-repo-handler@0.8.0#egg=cdcagg_oai
+-e git+https://github.com/cessda/cessda.cdc.aggregator.client@0.8.0#egg=cdcagg_client
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,8 +64,8 @@ git+https://gitlab.tuni.fi/fsd/kuha_client@master#egg=kuha_client
 
 # Use editable installs since we're using *.md docs from these repos in documentation
 
--e git+https://github.com/cessda/cessda.cdc.aggregator.shared-library@0.7.0#egg=cdcagg_common
--e git+https://github.com/cessda/cessda.cdc.aggregator.doc-store@0.5.0#egg=cdcagg_docstore
--e git+https://github.com/cessda/cessda.cdc.aggregator.oai-pmh-repo-handler@0.8.0#egg=cdcagg_oai
--e git+https://github.com/cessda/cessda.cdc.aggregator.client@0.8.0#egg=cdcagg_client
+-e git+https://github.com/cessda/cessda.cdc.aggregator.shared-library@0.8.1#egg=cdcagg_common
+-e git+https://github.com/cessda/cessda.cdc.aggregator.doc-store@0.6.0#egg=cdcagg_docstore
+-e git+https://github.com/cessda/cessda.cdc.aggregator.oai-pmh-repo-handler@0.9.0#egg=cdcagg_oai
+-e git+https://github.com/cessda/cessda.cdc.aggregator.client@0.9.0#egg=cdcagg_client
 


### PR DESCRIPTION
Closes #15 
Closes #16 

This can be merged after merging https://github.com/cessda/cessda.cdc.aggregator.doc-store/pull/36 to get correct version number for docstore.

The docs built in RTD from this branch can be seen at https://cessda-metadata-aggregator.readthedocs.io/en/devel/